### PR TITLE
Context item fixes

### DIFF
--- a/psi/application/__init__.py
+++ b/psi/application/__init__.py
@@ -47,7 +47,7 @@ class ExceptionHandler:
     def __enter__(self):
         sys.excepthook = sys.__excepthook__
 
-    def __exit__(self):
+    def __exit__(self, exc_type, exc_value, exc_tb):
         sys.excepthook = self
 
     def __call__(self, *args):

--- a/psi/context/context_item_view.enaml
+++ b/psi/context/context_item_view.enaml
@@ -159,7 +159,7 @@ template ContextItemTemplate(context_item, MemberType: Parameter):
         )
 
         Conditional:
-            condition = get_scope(context_item.scope, workbench) == 'trial'
+            condition << get_scope(context_item.scope, workbench) == 'trial'
             CheckBox:
                 checked := context_item.rove
 

--- a/psi/context/manifest.enaml
+++ b/psi/context/manifest.enaml
@@ -87,17 +87,6 @@ enamldef ContextManifest(PluginManifest): manifest:
         id = 'symbols'
 
     Extension:
-        name = PLUGIN_ID + '.default_items'
-        point = 'psi.context.items'
-
-        ContextGroup:
-            # This is a commonly used group that many plugins may wish to
-            # contribute to.
-            name = 'hardware_settings'
-            label = 'Hardware'
-            hide_when = 'never'
-
-    Extension:
         id = PLUGIN_ID + '.default_symbols'
         point = 'psi.context.symbols'
         ImportedSymbol:

--- a/psi/context/manifest.enaml
+++ b/psi/context/manifest.enaml
@@ -189,13 +189,25 @@ enamldef ContextManifest(PluginManifest): manifest:
                 selector_state = preferences['selectors']
                 meta_state = preferences['meta']
 
+                # We flatten the context group -> context item hierarchy here.
+                # Since context item names must be globally unique even if
+                # they're organized by context group, this allows us to move
+                # items between groups without having to migrate saved
+                # settings.
+                item_states = {}
+                for group_state in parameter_state.values():
+                    for k, v in group_state.items():
+                        if k in item_states:
+                            raise ValueError(f'Duplicate item in settings "{k}"')
+                        item_states[k] = v
+
                 log.debug('Setting context item states')
                 for item in plugin.context_items.values():
                     if not item.editable:
                         continue
-                    group_state = parameter_state.get(item.group_name, {})
-                    state = group_state.get(item.name, {})
-                    set_preferences(item, state)
+                    if item.name not in item_states:
+                        log.info('Could not find context item %s in saved state', item.name)
+                    set_preferences(item, item_states.get(item.name, {}))
 
                 log.debug('Setting selector states')
                 for selector in plugin.selectors.values():

--- a/psi/context/manifest.enaml
+++ b/psi/context/manifest.enaml
@@ -166,13 +166,13 @@ enamldef ContextManifest(PluginManifest): manifest:
                 for i in plugin.context_items.values():
                     if not i.editable:
                         continue
-                    group_state = parameter_state.setdefault(i.group_name, {})
+                    group_state = parameter_state.setdefault(i.parent.name, {})
                     group_state[i.name] = get_preferences(i)
 
                 # Build the selector state
                 selector_state = {}
                 for s in plugin.selectors.values():
-                    selector_state[s.name] = get_preferences(s)
+                    selector_state[s.name] = s.__getstate__()
 
                 # Build the meta state
                 meta_state = {}

--- a/psi/context/selector.py
+++ b/psi/context/selector.py
@@ -501,6 +501,8 @@ class FriendlyCartesianProduct(BaseSelector):
         if transform:
             transform_fn = self.get_field(item.name, 'transform_fn', lambda x: x)
             values = [transform_fn(v) for v in values]
+        if len(values) == 0:
+            raise ValueError(f'No values to test for {item.label}')
         return values
 
     def get_settings(self):

--- a/psi/context/selector_manifest.enaml
+++ b/psi/context/selector_manifest.enaml
@@ -344,23 +344,27 @@ enamldef FriendlyCartesianProductItem(Container):
 
 
 def get_description(selector, item, *args):
-    values = selector.get_values(item)
-    step_unit = selector.get_field(item.name, 'step_unit', '')
-    unit = selector.get_field(item.name, 'unit')
-    label = selector.get_field(item.name, 'user_friendly_name')
-    round_values = selector.get_field(item.name, 'round_values', False)
-    transform = selector.get_field(item.name, 'transform_to_gui', lambda x: x)
+    try:
+        values = selector.get_values(item, transform=True)
+        step_unit = selector.get_field(item.name, 'step_unit', '')
+        unit = selector.get_field(item.name, 'unit')
+        label = selector.get_field(item.name, 'user_friendly_name')
+        round_values = selector.get_field(item.name, 'round_values', False)
 
-    values = [transform(v) for v in values]
+        if len(values) == 0:
+            mesg = '''The current settings result in no values to test. Perhaps the
+            start value is greater than the end value?'''
+        else:
+            if round_values:
+                step = selector.get_value(item.name, 'step')
+                round_mesg = f'{label.capitalize()} are rounded to the nearest {step} {step_unit}.'
+            else:
+                round_mesg = ''
+            mesg = f'''{round_mesg}The current range is {values[0]:.1f} to
+            {values[-1]:.1f} {unit} for a total of {len(values)} {label}.'''
+    except ValueError as e:
+        mesg = str(e)
 
-    if round_values:
-        step = selector.get_value(item.name, 'step')
-        round_mesg = f'{label.capitalize()} are rounded to the nearest {step} {step_unit}.'
-    else:
-        round_mesg = ''
-
-    mesg = f'''{round_mesg}The current range is {values[0]:.1f} to
-    {values[-1]:.1f} {unit} for a total of {len(values)} {label}.'''
     mesg = re.sub(r'[\s\n\r]+', ' ', mesg).strip()
     return textwrap.fill(mesg)
 

--- a/psi/context/selector_manifest.enaml
+++ b/psi/context/selector_manifest.enaml
@@ -411,7 +411,7 @@ def friendly_cartesian_product_update_context(selector, event):
     # thresholding input data).
     context = event.workbench.get_plugin('psi.context')
     for name, param in context.parameters.items():
-        if name not in selector.context_detail and param.scope == 'trial':
+        if name not in selector.can_manage and param.scope == 'trial':
             param.rove = False
             param.scope = 'experiment'
 
@@ -422,7 +422,7 @@ def friendly_cartesian_product_update_context(selector, event):
         for item_name in selector.can_manage:
             item = context.parameters[item_name]
             item.rove = True
-            item.visible = False
+            #item.visible = False
 
 
 template SelectorTemplate(selector, MemberType: sc.FriendlyCartesianProduct):

--- a/psi/controller/calibration/calibrate.py
+++ b/psi/controller/calibration/calibrate.py
@@ -26,6 +26,8 @@ def merge_results(results, names=['ao_channel']):
             index = pd.MultiIndex.from_tuples(value.keys(), names=names)
             merged[key] = pd.DataFrame(value.values(), index=index)
         else:
+            for v in value.values():
+                v.attrs = {}
             merged[key] = pd.concat(value.values(), keys=value.keys(), names=names)
     return merged
 


### PR DESCRIPTION
This fixes a number of issues that I noticed when testing the software:

* Bug in excepthook callback.
* Don't add a default context item group. Not everyone wants this.
* Bug in loading settings when context item has been moved to new group.
* Bug in friendly cartesian selector
* Bugfix due to new version of pandas
