### PR TITLE
Enables threshold in RejectEpochs to be updated

### DIFF
--- a/psi/context/expression.py
+++ b/psi/context/expression.py
@@ -48,8 +48,8 @@ class ExpressionNamespace(Atom):
         '''
         self._locals = {}
 
-    def get_value(self, name, context=None):
-        if name not in self._locals:
+    def get_value(self, name, context=None, force_eval=False):
+        if force_eval or name not in self._locals:
             self._evaluate_value(name, context)
         return self._locals[name]
 

--- a/psi/context/plugin.py
+++ b/psi/context/plugin.py
@@ -45,8 +45,8 @@ class ContextLookup:
     def unique_values(self, item_name, iterator='default'):
         return self.__context_plugin.unique_values(item_name, iterator)
 
-    def lookup(self, attr):
-        cb = partial(getattr, self, attr)
+    def lookup(self, attr, force_eval=False):
+        cb = partial(self.__context_plugin.get_value, attr, force_eval)
         cb.is_lookup = True
         return cb
 
@@ -400,11 +400,12 @@ class ContextPlugin(PSIPlugin):
             log.debug(m)
             raise
 
-    def get_value(self, context_name):
+    def get_value(self, context_name, force_eval=False):
         if not self.initialized:
             raise ValueError(context_initialized_error)
         try:
-            return self._namespace.get_value(context_name)
+            return self._namespace.get_value(context_name,
+                                             force_eval=force_eval)
         except KeyError as e:
             m = f'{context_name} not defined.'
             raise ValueError(m) from e

--- a/psi/controller/input.py
+++ b/psi/controller/input.py
@@ -628,8 +628,11 @@ class RejectEpochs(EpochInput):
     '''
     Rejects epochs whose amplitude exceeds a specified threshold.
     '''
-    #: Reject threshold
-    threshold = d_(Float()).tag(metadata=True)
+    #: Reject threshold. Can either be a number or a callable. If callable,
+    #: must take no arguments and return a number to use. Each time new epochs
+    #: are available, the threshold will be obtained from the callable (thereby
+    #: allowing threshold to be changed during an experiment).
+    threshold = d_(Value()).tag(metadata=True)
 
     #: If `'absolute value'`, rejects epoch if the minimum or maximum exceeds
     #: the reject threshold. If `'amplitude'`, rejects epoch if the difference
@@ -661,7 +664,6 @@ class RejectEpochs(EpochInput):
         valid_cb = super().configure_callback()
         return pipeline.reject_epochs(self.threshold, self.mode,
                                       self.status_cb, valid_cb).send
-
 
 
 class Detrend(EpochInput):

--- a/psi/controller/plugin.py
+++ b/psi/controller/plugin.py
@@ -548,6 +548,7 @@ class ControllerPlugin(Plugin):
 
     def apply_changes(self):
         self.context.apply_changes()
+        return True
 
     def pause_experiment(self):
         raise NotImplementedError


### PR DESCRIPTION
To support the ability to update RejectEpochs, this also adds a `force_eval` to `ContextLookup.lookup` that forces re-evaluation of a variable (e.g., reject threshold) rather than returning the cached value.