### PR TITLE
Add ability to specify callback at end of experiment

### DIFF
--- a/examples/app/custom-stop-override/io_manifest.enaml
+++ b/examples/app/custom-stop-override/io_manifest.enaml
@@ -1,0 +1,28 @@
+from enaml.workbench.api import PluginManifest, Extension
+
+from psi.controller.engines.null import NullEngine
+from psi.controller.api import (HardwareAIChannel, HardwareAOChannel)
+
+
+enamldef IOManifest(PluginManifest): manifest:
+    '''
+    This defines the hardware connections that are specific to the computer of
+    interest.
+    '''
+    Extension:
+        id = 'backend'
+        point = 'psi.controller.io'
+
+        NullEngine: engine:
+            name = 'example'
+            master_clock = True
+
+            HardwareAOChannel:
+                label = 'AO'
+                name = 'speaker'
+                fs = 100e3
+
+            HardwareAIChannel:
+                label = 'AI'
+                name = 'microphone'
+                fs = 25e3

--- a/examples/app/custom-stop-override/launch.py
+++ b/examples/app/custom-stop-override/launch.py
@@ -1,0 +1,20 @@
+from psi import set_config
+
+
+def main():
+    import logging
+    logging.basicConfig(level='ERROR')
+
+    from psi.experiment.api import PSIWorkbench
+
+    workbench = PSIWorkbench()
+
+    set_config('EXPERIMENT', 'demo_experiment')
+    io_manifest = 'io_manifest.IOManifest'
+    manifests = ['startstop_controller.ControllerManifest']
+    workbench.register_core_plugins(io_manifest, manifests)
+    workbench.start_workspace('demo')
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/app/custom-stop-override/startstop_controller.enaml
+++ b/examples/app/custom-stop-override/startstop_controller.enaml
@@ -1,0 +1,27 @@
+import logging
+log = logging.getLogger(__name__)
+
+from enaml.stdlib.message_box import critical
+from enaml.workbench.api import Extension
+from enaml.workbench.core.api import Command
+from enaml.workbench.ui.api import Branding
+
+from psi.controller.api import ControllerManifest as BaseControllerManifest
+
+
+def ask_question(event):
+    critical(None, "Experiment over", "You just pressed the stop button!")
+
+
+enamldef ControllerManifest(BaseControllerManifest): manifest:
+
+    Extension:
+        id = 'simple.branding'
+        point = 'enaml.workbench.ui.branding'
+        Branding:
+            title = 'Demo of overriding stop command'
+
+    Extension:
+        id = 'wrapup'
+        point = 'psi.controller.wrapup'
+        factory = lambda w: ask_question

--- a/examples/app/launch.py
+++ b/examples/app/launch.py
@@ -1,19 +1,21 @@
 from psi import set_config
 
 
-def main():
+def main(manifests):
     import logging
     logging.basicConfig(level='ERROR')
 
     from psi.experiment.api import PSIWorkbench
+
     workbench = PSIWorkbench()
 
     set_config('EXPERIMENT', 'demo_experiment')
     io_manifest = 'io_manifest.IOManifest'
-    controller_manifests = ['simple_experiment.ControllerManifest']
-    workbench.register_core_plugins(io_manifest, controller_manifests)
+    workbench.register_core_plugins(io_manifest, manifests)
     workbench.start_workspace('demo')
 
 
 if __name__ == '__main__':
-    main()
+    #manifests = ['simple_experiment.ControllerManifest']
+    manifests = ['startstop_controller.ControllerManifest']
+    main(manifests)

--- a/examples/app/startstop_controller.enaml
+++ b/examples/app/startstop_controller.enaml
@@ -1,0 +1,27 @@
+import logging
+log = logging.getLogger(__name__)
+
+from enaml.stdlib.message_box import critical
+from enaml.workbench.api import Extension
+from enaml.workbench.core.api import Command
+from enaml.workbench.ui.api import Branding
+
+from psi.controller.api import ControllerManifest as BaseControllerManifest
+
+
+def ask_question(event):
+    critical(None, "Experiment over", "You just pressed the stop button!")
+
+
+enamldef ControllerManifest(BaseControllerManifest): manifest:
+
+    Extension:
+        id = 'simple.branding'
+        point = 'enaml.workbench.ui.branding'
+        Branding:
+            title = 'Demo of overriding stop command'
+
+    Extension:
+        id = 'wrapup'
+        point = 'psi.controller.wrapup'
+        factory = lambda w: ask_question

--- a/psi/application/__init__.py
+++ b/psi/application/__init__.py
@@ -53,13 +53,10 @@ class ExceptionHandler:
     def __call__(self, *args):
         with self:
             log.exception("Uncaught exception", exc_info=args)
-
             if self.workbench is not None:
-                controller = self.workbench.get_plugin('psi.controller')
-                try:
-                    controller.stop_experiment(skip_errors=True)
-                except:
-                    pass
+                core = self.workbench.get_plugin('enaml.workbench.core')
+                parameters = {'stop_reason': 'error', 'skip_errors': True}
+                core.invoke_command('psi.controller.stop', parameters)
                 window = self.workbench.get_plugin('enaml.workbench.ui').window
             else:
                 window = None

--- a/psi/context/plugin.py
+++ b/psi/context/plugin.py
@@ -207,10 +207,10 @@ class ContextPlugin(PSIPlugin):
                 # If, in the future, we need the ability to ignore missing
                 # parameters, I would add an attribute to the Expression class
                 # indicating that it's OK to ignore if the parameter does not exist.
-                raise ValueError(f'{expression.parameter} referenced by '
-                                 f'expression {expression.expression} '
-                                 'does not exist. Available names include '
-                                 f'{available_items}.')
+                log.warn(f'{expression.parameter} referenced by '
+                         f'expression {expression.expression} '
+                          'does not exist. Available names include '
+                         f'{available_items}.')
 
         load_manifests(context_groups.values(), self.workbench)
         self.context_expressions = context_expressions

--- a/psi/controller/engines/null.py
+++ b/psi/controller/engines/null.py
@@ -71,7 +71,7 @@ class NullEngine(Engine):
         self.t0 = time.time()
         self.t_ao = 0
         self.t_ai = 0
-        self.timer = threading.Timer(self.hw_ao_monitor_period)
+        #self.timer = threading.Timer(self.hw_ao_monitor_period)
 
     def stop(self):
         pass

--- a/psi/controller/engines/tdt/__init__.py
+++ b/psi/controller/engines/tdt/__init__.py
@@ -387,6 +387,9 @@ class TDTEngine(Engine):
         self._project.trigger('A', 'high')
 
     def stop(self):
+        deferred_call(self._stop)
+
+    def _stop(self):
         if not self._configured:
             return
 

--- a/psi/controller/manifest.enaml
+++ b/psi/controller/manifest.enaml
@@ -113,8 +113,9 @@ def stop_experiment(event):
     # Todo: this does not capture *everything* possible (e.g., stopping
     # experiment leads to a cascade of actions).
     stop_reason = event.parameters.get('stop_reason', '')
+    skip_errors = event.parameters.get('skip_errors', True)
     controller = event.workbench.get_plugin('psi.controller')
-    results = set(controller.stop_experiment(skip_errors=True))
+    results = set(controller.stop_experiment(skip_errors=skip_errors))
     mesg = '\n'.join(r.strip() for r in results if r is not None)
     controller._wrapup(mesg, stop_reason)
 

--- a/psi/controller/manifest.enaml
+++ b/psi/controller/manifest.enaml
@@ -115,8 +115,13 @@ def stop_experiment(event):
     controller = event.workbench.get_plugin('psi.controller')
     results = set(controller.stop_experiment(skip_errors=True))
     mesg = '\n'.join(r.strip() for r in results if r is not None)
-    if mesg:
-        deferred_call(information, None, 'Experiment done', mesg)
+    controller._wrapup(mesg)
+
+
+def show_results(event):
+    message = event.parameters.get('message')
+    if message:
+        information(None, 'Experiment done', message)
 
 
 def invoke_actions(event):
@@ -169,6 +174,15 @@ enamldef ControllerManifest(ControllerManifestBase): manifest:
 
     ExtensionPoint:
         id = 'psi.controller.actions'
+
+    ExtensionPoint:
+        id = 'psi.controller.wrapup'
+
+    Extension:
+        id = 'psi.controller.default_wrapup'
+        point = 'psi.controller.wrapup'
+        factory = lambda w: show_results
+        rank = -1000
 
     Extension:
         id = PLUGIN_ID + '.branding'

--- a/psi/controller/manifest.enaml
+++ b/psi/controller/manifest.enaml
@@ -112,12 +112,14 @@ def start_experiment(event):
 def stop_experiment(event):
     # Todo: this does not capture *everything* possible (e.g., stopping
     # experiment leads to a cascade of actions).
+    error_message = event.parameters.get('error_message', '')
     stop_reason = event.parameters.get('stop_reason', '')
     skip_errors = event.parameters.get('skip_errors', True)
     controller = event.workbench.get_plugin('psi.controller')
     results = set(controller.stop_experiment(skip_errors=skip_errors))
     mesg = '\n'.join(r.strip() for r in results if r is not None)
-    controller._wrapup(mesg, stop_reason)
+    controller._wrapup(message=mesg, stop_reason=stop_reason,
+                       error_message=error_message)
 
 
 def show_results(event):
@@ -260,8 +262,7 @@ enamldef ControllerManifest(ControllerManifestBase): manifest:
                 triggered ::
                     plugin = workbench.get_plugin('enaml.workbench.core')
                     plugin.invoke_command('psi.controller.start')
-                enabled << workbench.get_plugin('psi.controller').experiment_state \
-                    == 'initialized'
+                enabled << controller.experiment_state == 'initialized'
             Action:
                 text = 'Stop'
                 tool_tip = 'Stop experiment'

--- a/psi/controller/manifest.enaml
+++ b/psi/controller/manifest.enaml
@@ -112,10 +112,11 @@ def start_experiment(event):
 def stop_experiment(event):
     # Todo: this does not capture *everything* possible (e.g., stopping
     # experiment leads to a cascade of actions).
+    stop_reason = event.parameters.get('stop_reason', '')
     controller = event.workbench.get_plugin('psi.controller')
     results = set(controller.stop_experiment(skip_errors=True))
     mesg = '\n'.join(r.strip() for r in results if r is not None)
-    controller._wrapup(mesg)
+    controller._wrapup(mesg, stop_reason)
 
 
 def show_results(event):
@@ -264,8 +265,9 @@ enamldef ControllerManifest(ControllerManifestBase): manifest:
                 text = 'Stop'
                 tool_tip = 'Stop experiment'
                 triggered ::
+                    parameters = {'stop_reason': 'user clicked stop button'}
                     plugin = workbench.get_plugin('enaml.workbench.core')
-                    plugin.invoke_command('psi.controller.stop')
+                    plugin.invoke_command('psi.controller.stop', parameters)
                 enabled <<  controller.experiment_state not in ('initialized', 'stopped')
             Action:
                 separator = True

--- a/psi/controller/plugin.py
+++ b/psi/controller/plugin.py
@@ -27,6 +27,7 @@ from .experiment_action import (ExperimentAction, ExperimentActionBase,
 
 IO_POINT = 'psi.controller.io'
 ACTION_POINT = 'psi.controller.actions'
+WRAPUP_POINT = 'psi.controller.wrapup'
 
 
 def get_obj(o, klass):
@@ -219,6 +220,22 @@ class ControllerPlugin(Plugin):
 
     def stop(self):
         self._unbind_observers()
+
+    def _wrapup(self, message):
+        workbench = self.workbench
+        point = workbench.get_extension_point(WRAPUP_POINT)
+        extensions = point.extensions
+        if not extensions:
+            msg = "no contributions to the '%s' extension point"
+            raise RuntimeError(msg % WRAPUP_POINT)
+
+        extension = extensions[-1]
+        if extension.factory is None:
+            msg = "extension '%s' does not declare a window factory"
+            raise ValueError(msg % extension.qualified_id)
+
+        cb = extension.factory(workbench)
+        cb(message)
 
     def _bind_observers(self):
         self.workbench.get_extension_point(IO_POINT) \

--- a/psi/experiment/workbench.py
+++ b/psi/experiment/workbench.py
@@ -59,6 +59,8 @@ class PSIWorkbench(Workbench):
             manifests = []
 
         for manifest in controller_manifests:
+            if isinstance(manifest, str):
+                manifest = load_manifest(manifest)()
             log.info('Registering %r', manifest)
             manifests.append(manifest)
             self.register(manifest)


### PR DESCRIPTION
This adds an extension to the controller that can contribute a callback point for a custom post-experiment action.
